### PR TITLE
Fix JGroups crash with SLF4J on JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <spring.version>5.1.4.RELEASE</spring.version>
         <spring.boot.version>2.1.2.RELEASE</spring.boot.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jgroups.version>4.0.6.Final</jgroups.version>
+        <jgroups.version>4.1.2.Final</jgroups.version>
         <mockito.version>2.15.0</mockito.version>
     </properties>
 


### PR DESCRIPTION
See https://issues.jboss.org/browse/JGRP-2307 -- issue is fixed in newer JGroups
versions, so upgrade to a more recent one.