### PR TITLE
[#1382] Support Spring Boot DevTools

### DIFF
--- a/jgroups/pom.xml
+++ b/jgroups/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2018. Axon Framework
+  ~ Copyright (c) 2010-2020. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -55,6 +55,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>

--- a/jgroups/src/main/resources/META-INF/spring-devtools.properties
+++ b/jgroups/src/main/resources/META-INF/spring-devtools.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2010-2020. Axon Framework
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+restart.include.axon-jgroups=axon-jgroups-${project.version}.jar
+restart.include.axon-jgroups-spring-boot-autoconfigure=axon-jgroups-spring-boot-autoconfigure-${project.version}.jar


### PR DESCRIPTION
This pull request introduces a `spring-devtools.properties` file, including the modules required for restart. After local testing (at this stage uncertain how to provide test cases for this) it showed that [Spring Boot Devtools](https://docs.spring.io/spring-boot/docs/1.5.16.RELEASE/reference/html/using-boot-devtools.html) threw exceptions if any of the added jars was not included for restart.
With the adjustments in place, all worked as desired. An additional adjustment was made to the `pom.xml` to allow filtering of the project version into the `spring-devtools.properties` file.

This pull request resolves [#1382](https://github.com/AxonFramework/AxonFramework/issues/1382)